### PR TITLE
Update Docker build argument for port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.12
 
+# Port configuration (can be overridden via build-arg)
+ARG PORT=5000
+ENV PORT=$PORT
+
 # Install system dependencies
 RUN apt-get update && \
     apt-get install -y ffmpeg libportaudio2 && \
@@ -16,7 +20,7 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 COPY . .
 
 # Expose Flask port
-EXPOSE 5000
+EXPOSE ${PORT}
 
 # Default command (can be overridden by docker compose)
 CMD ["python", "dream_recorder.py"]

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ docker compose -f docker-compose.dev.yml up -d
 ./dreamctl config
 ```
 
-The app will be available at [http://localhost:5000](http://localhost:5000) (unless you choose to change the default port in the config)
+The app will be available at [http://localhost:5000](http://localhost:5000) by default. The server port can be adjusted in `.env` (`PORT`) and `config.json`.
+After changing the port you must rebuild the image with `docker compose build`.
 
 To simulate sensor button presses, you can either use the on-screen developer console (available when running in dev mode), or:
    - Note: You will need Python 3.12 installed on your system - [Python documentation](https://wiki.python.org/moin/BeginnersGuide/Download)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,9 @@
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        PORT: ${PORT}
     ports:
       - "${PORT}:${PORT}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        PORT: ${PORT}
     ports:
       - "${PORT}:${PORT}"
     volumes:


### PR DESCRIPTION
## Summary
- add `PORT` build argument in `Dockerfile`
- pass the build argument in both compose files
- document port configuration and rebuild steps in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858783b3654832c845f010e5f7b0ac1