### PR TITLE
Update README with media access section

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,25 @@ You can access the dream management page from your computer by going to http://d
    |--|--|
 </details>
 
+
+## Accessing Generated Media
+The `docker-compose.dev.yml` configuration stores database, media, and log files in **named volumes**: `db-data`, `media-data`, and `logs-data`. Consequently, anything under `media/` lives inside the container by default.
+
+To copy generated videos out of the container, reference the `app` service with `docker compose cp`:
+
+```bash
+docker compose cp app:/app/media/video/<file> ./my-videos/
+```
+
+For direct access, you can edit `docker-compose.dev.yml` to mount a host directory:
+
+```yaml
+services:
+  app:
+    volumes:
+      - ./media:/app/media
+```
+
 ## Troubleshooting
 - **Logs:**
   - App logs: `docker compose logs -f`


### PR DESCRIPTION
## Summary
- add *Accessing Generated Media* section in README

## Testing
- `./dreamctl test` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6858778fd7bc832c8c5a3ba766a30666)